### PR TITLE
Func/gerar relatorio de responsavel com nota pendente

### DIFF
--- a/src/main/java/br/com/zup/zupayments/controllers/NotaFiscalController.java
+++ b/src/main/java/br/com/zup/zupayments/controllers/NotaFiscalController.java
@@ -1,7 +1,9 @@
 package br.com.zup.zupayments.controllers;
 
 import br.com.zup.zupayments.dtos.notafiscal.entrada.CadastrarNotaFiscalDTO;
+import br.com.zup.zupayments.dtos.pedidodecompras.entrada.FiltroPedidoDeCompraComNotaFiscalPendenteDTO;
 import br.com.zup.zupayments.models.NotaFiscal;
+import br.com.zup.zupayments.models.PedidoDeCompra;
 import br.com.zup.zupayments.services.NotaFiscalService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/br/com/zup/zupayments/controllers/PedidoDeCompraController.java
+++ b/src/main/java/br/com/zup/zupayments/controllers/PedidoDeCompraController.java
@@ -1,6 +1,7 @@
 package br.com.zup.zupayments.controllers;
 
 import br.com.zup.zupayments.dtos.pedidodecompras.entrada.EntradaCadastroPedidoDeCompraDTO;
+import br.com.zup.zupayments.dtos.pedidodecompras.entrada.FiltroPedidoDeCompraComNotaFiscalPendenteDTO;
 import br.com.zup.zupayments.dtos.pedidodecompras.saida.SaidaCadastroPedidoDeCompraDTO;
 import br.com.zup.zupayments.models.PedidoDeCompra;
 import br.com.zup.zupayments.services.PedidoDeCompraService;
@@ -49,5 +50,15 @@ public class PedidoDeCompraController {
             @RequestParam(name = "ativo", defaultValue = "false") Boolean ativo
     ) {
         return pedidoDeCompraService.obterTodosPedidosDeCompraComResponsavelAtivo(ativo);
+    }
+
+    @GetMapping("pendentes")
+    @ResponseStatus(HttpStatus.OK)
+    public Iterable<PedidoDeCompra> obterPedidosComNotaFiscaisPendentesDeEnvio(
+            @ModelAttribute FiltroPedidoDeCompraComNotaFiscalPendenteDTO filtro
+    ) {
+        return pedidoDeCompraService.obterTodosPedidosDeCompraComValorMaiorQueZeroEResponsaveisAtivo(
+                filtro.getValorMinimo(), filtro.getAtivo(), filtro.getDataInicial()
+        );
     }
 }

--- a/src/main/java/br/com/zup/zupayments/dtos/pedidodecompras/entrada/FiltroPedidoDeCompraComNotaFiscalPendenteDTO.java
+++ b/src/main/java/br/com/zup/zupayments/dtos/pedidodecompras/entrada/FiltroPedidoDeCompraComNotaFiscalPendenteDTO.java
@@ -1,0 +1,40 @@
+package br.com.zup.zupayments.dtos.pedidodecompras.entrada;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+
+public class FiltroPedidoDeCompraComNotaFiscalPendenteDTO {
+    private Double valorMinimo;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd/MM/yyyy")
+    private LocalDate dataInicial;
+    private Boolean ativo;
+
+    public FiltroPedidoDeCompraComNotaFiscalPendenteDTO() {
+    }
+
+    public Double getValorMinimo() {
+        return valorMinimo;
+    }
+
+    public void setValorMinimo(Double valorMinimo) {
+        this.valorMinimo = valorMinimo;
+    }
+
+    public LocalDate getDataInicial() {
+        return dataInicial;
+    }
+
+    public void setDataInicial(LocalDate dataInicial) {
+        this.dataInicial = dataInicial;
+    }
+
+    public Boolean getAtivo() {
+        return ativo;
+    }
+
+    public void setAtivo(Boolean ativo) {
+        this.ativo = ativo;
+    }
+}

--- a/src/main/java/br/com/zup/zupayments/models/PedidoDeCompra.java
+++ b/src/main/java/br/com/zup/zupayments/models/PedidoDeCompra.java
@@ -3,6 +3,7 @@ package br.com.zup.zupayments.models;
 import br.com.zup.zupayments.enums.FormaDePagamento;
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.util.Objects;
 
 @Entity
 @Table(name = "pedidos_de_compras")
@@ -109,5 +110,18 @@ public class PedidoDeCompra {
 
     public void setCancelado(Boolean cancelado) {
         this.cancelado = cancelado;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PedidoDeCompra that = (PedidoDeCompra) o;
+        return Objects.equals(numeroDePedido, that.numeroDePedido);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(numeroDePedido);
     }
 }

--- a/src/main/java/br/com/zup/zupayments/repositories/NotaFiscalRepository.java
+++ b/src/main/java/br/com/zup/zupayments/repositories/NotaFiscalRepository.java
@@ -3,5 +3,8 @@ package br.com.zup.zupayments.repositories;
 import br.com.zup.zupayments.models.NotaFiscal;
 import org.springframework.data.repository.CrudRepository;
 
+import java.time.LocalDate;
+
 public interface NotaFiscalRepository extends CrudRepository<NotaFiscal, Long> {
+    Iterable<NotaFiscal> findAllByDataDeEmissaoBetween(LocalDate dataInicial, LocalDate dataFinal);
 }

--- a/src/main/java/br/com/zup/zupayments/repositories/PedidoDeCompraRespository.java
+++ b/src/main/java/br/com/zup/zupayments/repositories/PedidoDeCompraRespository.java
@@ -5,4 +5,5 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface PedidoDeCompraRespository extends CrudRepository<PedidoDeCompra, Long> {
     Iterable<PedidoDeCompra> findAllByResponsavelAtivo(Boolean ativo);
+    Iterable<PedidoDeCompra> findAllByValorAproximadoGreaterThanAndResponsavelAtivo(Double valorMinimo, Boolean ativo);
 }

--- a/src/main/java/br/com/zup/zupayments/services/NotaFiscalService.java
+++ b/src/main/java/br/com/zup/zupayments/services/NotaFiscalService.java
@@ -7,6 +7,8 @@ import br.com.zup.zupayments.models.PedidoDeCompra;
 import br.com.zup.zupayments.repositories.NotaFiscalRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -68,5 +70,10 @@ public class NotaFiscalService {
         NotaFiscal notaFiscalAtual = pesquisarNotaFiscalPeloId(id);
         notaFiscalAtual.setCancelar(!notaFiscalAtual.getCancelar());
         return notaFiscalRepository.save(notaFiscalAtual);
+    }
+
+    public Iterable<NotaFiscal> obterTodasNotaFiscalComIntervaloDeDataDeEmissao(
+            LocalDate dataInicial, LocalDate dataFinal) {
+        return notaFiscalRepository.findAllByDataDeEmissaoBetween(dataInicial, dataFinal);
     }
 }

--- a/src/main/java/br/com/zup/zupayments/services/PedidoDeCompraService.java
+++ b/src/main/java/br/com/zup/zupayments/services/PedidoDeCompraService.java
@@ -1,11 +1,15 @@
 package br.com.zup.zupayments.services;
 
 import br.com.zup.zupayments.exceptions.erros.PedidoDeCompraNaoExisteException;
+import br.com.zup.zupayments.models.NotaFiscal;
 import br.com.zup.zupayments.models.PedidoDeCompra;
 import br.com.zup.zupayments.repositories.PedidoDeCompraRespository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -59,8 +63,25 @@ public class PedidoDeCompraService {
     }
 
     public Iterable<PedidoDeCompra> obterTodosPedidosDeCompraComValorMaiorQueZeroEResponsaveisAtivo(
-            Double valorMinimo, Boolean ativo
-    ) {
-        return pedidoDeCompraRespository.findAllByValorAproximadoGreaterThanAndResponsavelAtivo(valorMinimo, ativo);
+            Double valorMinimo, Boolean ativo, LocalDate dataInicial) {
+        Iterable<NotaFiscal> notasFiscais = notaFiscalService.obterTodasNotaFiscalComIntervaloDeDataDeEmissao(
+                dataInicial, LocalDate.now());
+        Iterable<PedidoDeCompra> pedidoDeCompras = pedidoDeCompraRespository
+                .findAllByValorAproximadoGreaterThanAndResponsavelAtivo(valorMinimo, ativo);
+        return verificarPendenciasDeNotaFiscal((List<NotaFiscal>) notasFiscais, (List<PedidoDeCompra>) pedidoDeCompras);
+    }
+
+    private Iterable<PedidoDeCompra> verificarPendenciasDeNotaFiscal(List<NotaFiscal> notaFiscals,
+                                                                     List<PedidoDeCompra> pedidoDeCompras) {
+        for (PedidoDeCompra pedidoDeCompra : pedidoDeCompras) {
+            for (NotaFiscal notaFiscal : notaFiscals) {
+                if (notaFiscal.getDataDeEmissao().getMonthValue() == LocalDate.now().getMonthValue()
+                && notaFiscal.getPedidoDeCompra().contains(pedidoDeCompra)) {
+                    pedidoDeCompras.remove(pedidoDeCompra);
+                }
+            }
+        }
+
+        return pedidoDeCompras;
     }
 }

--- a/src/main/java/br/com/zup/zupayments/services/PedidoDeCompraService.java
+++ b/src/main/java/br/com/zup/zupayments/services/PedidoDeCompraService.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/br/com/zup/zupayments/services/PedidoDeCompraService.java
+++ b/src/main/java/br/com/zup/zupayments/services/PedidoDeCompraService.java
@@ -54,4 +54,10 @@ public class PedidoDeCompraService {
     public Iterable<PedidoDeCompra> obterTodosPedidosDeCompraComResponsavelAtivo(Boolean ativo) {
         return pedidoDeCompraRespository.findAllByResponsavelAtivo(ativo);
     }
+
+    public Iterable<PedidoDeCompra> obterTodosPedidosDeCompraComValorMaiorQueZeroEResponsaveisAtivo(
+            Double valorMinimo, Boolean ativo
+    ) {
+        return pedidoDeCompraRespository.findAllByValorAproximadoGreaterThanAndResponsavelAtivo(valor, ativo);
+    }
 }

--- a/src/main/java/br/com/zup/zupayments/services/PedidoDeCompraService.java
+++ b/src/main/java/br/com/zup/zupayments/services/PedidoDeCompraService.java
@@ -11,17 +11,20 @@ import java.util.Optional;
 @Service
 public class PedidoDeCompraService {
 
-    private PedidoDeCompraRespository pedidoDeCompraRespository;
+    private final PedidoDeCompraRespository pedidoDeCompraRespository;
     private final ResponsavelService responsavelService;
     private final FornecedorService fornecedorService;
+    private final NotaFiscalService notaFiscalService;
 
     @Autowired
     public PedidoDeCompraService(PedidoDeCompraRespository pedidoDeCompraRespository,
                                  ResponsavelService responsavelService,
-                                 FornecedorService fornecedorService) {
+                                 FornecedorService fornecedorService,
+                                 NotaFiscalService notaFiscalService) {
         this.pedidoDeCompraRespository = pedidoDeCompraRespository;
         this.responsavelService = responsavelService;
         this.fornecedorService = fornecedorService;
+        this.notaFiscalService = notaFiscalService;
     }
 
     public PedidoDeCompra cadastrarNovoPedidoDeCompra(PedidoDeCompra pedidoDeCompra) {
@@ -58,6 +61,6 @@ public class PedidoDeCompraService {
     public Iterable<PedidoDeCompra> obterTodosPedidosDeCompraComValorMaiorQueZeroEResponsaveisAtivo(
             Double valorMinimo, Boolean ativo
     ) {
-        return pedidoDeCompraRespository.findAllByValorAproximadoGreaterThanAndResponsavelAtivo(valor, ativo);
+        return pedidoDeCompraRespository.findAllByValorAproximadoGreaterThanAndResponsavelAtivo(valorMinimo, ativo);
     }
 }

--- a/src/test/java/br/com/zup/zupayments/ZupaymentsApplicationTests.java
+++ b/src/test/java/br/com/zup/zupayments/ZupaymentsApplicationTests.java
@@ -1,5 +1,6 @@
 package br.com.zup.zupayments;
 
+import br.com.zup.zupayments.controllers.FornecedorControllerTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 

--- a/src/test/java/br/com/zup/zupayments/services/NotaFiscalServiceTest.java
+++ b/src/test/java/br/com/zup/zupayments/services/NotaFiscalServiceTest.java
@@ -41,7 +41,7 @@ public class NotaFiscalServiceTest {
     private PedidoDeCompra pedidoDeCompra;
 
     @BeforeEach
-        public void setup(){
+    public void setup(){
 
         this.notaFiscalteste = new NotaFiscal();
 
@@ -72,6 +72,7 @@ public class NotaFiscalServiceTest {
         this.notaFiscalteste.setDataDeEnvio(LocalDate.now());
         this.notaFiscalteste.setResponsavel(this.responsavel);
         this.notaFiscalteste.setPedidoDeCompra(Arrays.asList(this.pedidoDeCompra));
+        this.notaFiscalteste.setCancelar(false);
     }
 
     @Test
@@ -87,11 +88,11 @@ public class NotaFiscalServiceTest {
 
     @Test
     public void testarAtivarOuDesativarNotaFiscal() {
+        notaFiscalteste.setId(1L);
         Optional<NotaFiscal> optionalNotaFiscal = Optional.of(notaFiscalteste);
         Mockito.when(notaFiscalRepository.findById(Mockito.anyLong())).thenReturn(optionalNotaFiscal);
         Mockito.when(notaFiscalRepository.save(Mockito.any())).thenReturn(notaFiscalteste);
         NotaFiscal teste = notaFiscalService.cancelarNF(1L);
-
         Assertions.assertEquals(teste, notaFiscalteste);
     }
 


### PR DESCRIPTION
- Refatorar os testes de controlers para converter as datas nos JSON
- Criar dois métodos customizados de consulta ao banco no pedido de compra e na nota fiscal
- criado método no serviço de nota fiscal para pesquisar as notas em um intervalo de data de emissão
- Criar método para gerar relatório de pedidos que possuem notas pendentes